### PR TITLE
Objects merging when on top of each other

### DIFF
--- a/Assets/Playground assets/FirstPersonController/Scenes/Playground.unity
+++ b/Assets/Playground assets/FirstPersonController/Scenes/Playground.unity
@@ -334,6 +334,10 @@ PrefabInstance:
       propertyPath: m_Name
       value: InteractableSpotlight
       objectReference: {fileID: 0}
+    - target: {fileID: 4108905215669901893, guid: 86855c10acd1eb54b9fb5af4e3ceabf2, type: 3}
+      propertyPath: m_Enabled
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 6711570098032760964, guid: 86855c10acd1eb54b9fb5af4e3ceabf2, type: 3}
       propertyPath: m_Axis.x
       value: 0
@@ -360,7 +364,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 9064626900170803404, guid: 86855c10acd1eb54b9fb5af4e3ceabf2, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 8.879174
+      value: 9.469483
       objectReference: {fileID: 0}
     - target: {fileID: 9064626900170803404, guid: 86855c10acd1eb54b9fb5af4e3ceabf2, type: 3}
       propertyPath: m_LocalPosition.y
@@ -368,23 +372,23 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 9064626900170803404, guid: 86855c10acd1eb54b9fb5af4e3ceabf2, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 1.5178328
+      value: 2.065116
       objectReference: {fileID: 0}
     - target: {fileID: 9064626900170803404, guid: 86855c10acd1eb54b9fb5af4e3ceabf2, type: 3}
       propertyPath: m_LocalRotation.w
-      value: 1
+      value: 0.7333266
       objectReference: {fileID: 0}
     - target: {fileID: 9064626900170803404, guid: 86855c10acd1eb54b9fb5af4e3ceabf2, type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 9064626900170803404, guid: 86855c10acd1eb54b9fb5af4e3ceabf2, type: 3}
       propertyPath: m_LocalRotation.y
-      value: 0
+      value: -0.67987657
       objectReference: {fileID: 0}
     - target: {fileID: 9064626900170803404, guid: 86855c10acd1eb54b9fb5af4e3ceabf2, type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 9064626900170803404, guid: 86855c10acd1eb54b9fb5af4e3ceabf2, type: 3}
       propertyPath: m_LocalEulerAnglesHint.x
@@ -392,7 +396,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 9064626900170803404, guid: 86855c10acd1eb54b9fb5af4e3ceabf2, type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
+      value: -85.668
       objectReference: {fileID: 0}
     - target: {fileID: 9064626900170803404, guid: 86855c10acd1eb54b9fb5af4e3ceabf2, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
@@ -905,15 +909,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7853901641460012846, guid: ae8431a0ebce48f4eaf7dd8dc01b58d4, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 3.21
+      value: 3.33
       objectReference: {fileID: 0}
     - target: {fileID: 7853901641460012846, guid: ae8431a0ebce48f4eaf7dd8dc01b58d4, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 1.19
+      value: 0.55
       objectReference: {fileID: 0}
     - target: {fileID: 7853901641460012846, guid: ae8431a0ebce48f4eaf7dd8dc01b58d4, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 3.69
+      value: 2.75
       objectReference: {fileID: 0}
     - target: {fileID: 7853901641460012846, guid: ae8431a0ebce48f4eaf7dd8dc01b58d4, type: 3}
       propertyPath: m_LocalRotation.w

--- a/Assets/Playground assets/FirstPersonController/Scenes/Playground.unity
+++ b/Assets/Playground assets/FirstPersonController/Scenes/Playground.unity
@@ -905,7 +905,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7853901641460012846, guid: ae8431a0ebce48f4eaf7dd8dc01b58d4, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -0.7
+      value: 3.21
       objectReference: {fileID: 0}
     - target: {fileID: 7853901641460012846, guid: ae8431a0ebce48f4eaf7dd8dc01b58d4, type: 3}
       propertyPath: m_LocalPosition.y

--- a/Assets/Scripts/Light/VisibleObject.cs
+++ b/Assets/Scripts/Light/VisibleObject.cs
@@ -77,11 +77,8 @@ public class VisibleObject : MonoBehaviour
         VisibleObject visibleObject = collision.collider.GetComponent<VisibleObject>();
         if(visibleObject != null && visibleObject.justMadeVisible)
         {
-            if(visibleObject.gameObject.GetComponent<Rigidbody>() != null && gameObject.GetComponent<Rigidbody>() != null)
-            {
-                FixedJoint joint = gameObject.AddComponent<FixedJoint>();
-                joint.connectedBody = visibleObject.gameObject.GetComponent<Rigidbody>();
-            }
+            AddJoint(visibleObject);
+            visibleObject.AddJoint(this);
         }
     }
 
@@ -110,6 +107,34 @@ public class VisibleObject : MonoBehaviour
         }
         _collider.enabled = false;
         visible = false;
+
+        gameObject.GetComponent<FixedJoint>().connectedBody.gameObject.GetComponent<VisibleObject>().RemoveJoints();
+        RemoveJoints();
+    }
+
+    public void AddJoint(VisibleObject visibleObject)
+    {
+        if(visibleObject.gameObject.GetComponent<Rigidbody>() != null && gameObject.GetComponent<Rigidbody>() != null)
+            {
+                FixedJoint joint = gameObject.AddComponent<FixedJoint>();
+                joint.connectedBody = visibleObject.gameObject.GetComponent<Rigidbody>();
+            }
+    }
+
+    public void RemoveJoints()
+    {
+        if(gameObject.GetComponent<FixedJoint>() != null)
+            {
+                FixedJoint[] joints = GetComponents<FixedJoint>();
+                foreach (var joint in joints)
+                {
+                    Rigidbody connectedBody = joint.connectedBody;
+                    
+                    
+                    Destroy(gameObject.GetComponent<FixedJoint>());
+                    return;
+                }
+            }
     }
 
 


### PR DESCRIPTION
VisibleObjects can merge/connect with multiple other visibleObjects. Some of the code should maybe be moved outside the VisibleObject script at some point.
It is done by using FixedJoints (which connects with a rigidbody) and this currently provides an issue for visibleObjects without a rigidbody.
Also, some slight jumping of the objects happen when shining light on objects on top of each other.